### PR TITLE
Gearing the app towards a mobile environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,8 @@
             let wind = WIND_PEI;    // Auto-flows to TON at first nextWind()
             let honba = 0;
 
+            let wakeLock = null;    // Used for UI locking in window.onload
+
             function updateDisplay() {
                 WIND_DISPLAY.innerText  = `${WINDS[wind]}`;
                 ROUND_DISPLAY.innerText = `${round}局`;
@@ -210,12 +212,16 @@
             // Mobile features
 
             async function noSleep() {
-                const wakeLock = await navigator.wakeLock.request("screen");
+                try {
+                    wakeLock = await navigator.wakeLock.request("screen");
 
-                // If we are no longer allowed to block sleep, attempt reblock
-                wakeLock.addEventListener("release", () => {
-                    noSleep();
-                });
+                    // Attempt reblock if wakeLock is released
+                    wakeLock.addEventListener("release", () => {
+                        noSleep();
+                    });
+                } catch (err) {
+                    console.log(`Caught ${err.name}, wakeLock will not be called. (${err.message})`);
+                }
             }
 
 
@@ -234,24 +240,20 @@
                 nextWind();
                 updateDisplay();
 
-                if (navigator.wakeLock) {
-                    try {
-                        noSleep();          // Starts async loop
-                    } catch (err) {
-                        console.log(`Caught ${err}, wakeLock will not be called.`);
-                    }
+                if ("wakeLock" in navigator) {
+                    noSleep();          // Starts async loop
                 } else {
                     console.log(`wakeLock does not exist, wakeLock will not be called.`);
                 }
+
+                ROUND_INFO.addEventListener("click", nextRound);
+                HONBA_DISPLAY.addEventListener("click", nextHonba);
+
+                TON_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+                NAN_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+                SHAA_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+                PEI_ELEMENT.addEventListener("dblclick", toggleFullscreen);
             }
-
-            ROUND_INFO.addEventListener("click", nextRound);
-            HONBA_DISPLAY.addEventListener("click", nextHonba);
-
-            TON_ELEMENT.addEventListener("dblclick", toggleFullscreen);
-            NAN_ELEMENT.addEventListener("dblclick", toggleFullscreen);
-            SHAA_ELEMENT.addEventListener("dblclick", toggleFullscreen);
-            PEI_ELEMENT.addEventListener("dblclick", toggleFullscreen);
         </script>
     </body>
 </html

--- a/index.html
+++ b/index.html
@@ -206,7 +206,9 @@
             }
 
 
+
             // Mobile features
+
             async function noSleep() {
                 const wakeLock = await navigator.wakeLock.request("screen");
 
@@ -215,6 +217,15 @@
                     noSleep();
                 });
             }
+
+
+            function toggleFullscreen() {
+                if (document.fullscreenElement === null)
+                    document.documentElement.requestFullscreen();
+                else
+                    document.exitFullscreen();
+            }
+
 
 
             // Main
@@ -229,6 +240,11 @@
 
             ROUND_INFO.addEventListener("click", nextRound);
             HONBA_DISPLAY.addEventListener("click", nextHonba);
+
+            TON_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+            NAN_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+            SHAA_ELEMENT.addEventListener("dblclick", toggleFullscreen);
+            PEI_ELEMENT.addEventListener("dblclick", toggleFullscreen);
         </script>
     </body>
 </html

--- a/index.html
+++ b/index.html
@@ -234,8 +234,15 @@
                 nextWind();
                 updateDisplay();
 
-                if (navigator.wakeLock)
-                    noSleep();          // Starts async loop
+                if (navigator.wakeLock) {
+                    try {
+                        noSleep();          // Starts async loop
+                    } catch (err) {
+                        console.log(`Caught ${err}, wakeLock will not be called.`);
+                    }
+                } else {
+                    console.log(`wakeLock does not exist, wakeLock will not be called.`);
+                }
             }
 
             ROUND_INFO.addEventListener("click", nextRound);

--- a/index.html
+++ b/index.html
@@ -236,16 +236,25 @@
 
             // Main
             window.onload = () => {
+                // Setting up state
                 nextRound();
                 nextWind();
                 updateDisplay();
 
+                // Reclaiming wake lock
+                document.addEventListener("visibilitychange", async () => {
+                    if (wakeLock !== null && document.visibilityState === "visible")
+                        noSleep();
+                });
+
+                // Setting up wake lock
                 if ("wakeLock" in navigator) {
                     noSleep();          // Starts async loop
                 } else {
                     console.log(`wakeLock does not exist, wakeLock will not be called.`);
                 }
 
+                // Bindings
                 ROUND_INFO.addEventListener("click", nextRound);
                 HONBA_DISPLAY.addEventListener("click", nextHonba);
 

--- a/index.html
+++ b/index.html
@@ -205,11 +205,26 @@
                 updateDisplay();
             }
 
+
+            // Mobile features
+            async function noSleep() {
+                const wakeLock = await navigator.wakeLock.request("screen");
+
+                // If we are no longer allowed to block sleep, attempt reblock
+                wakeLock.addEventListener("release", () => {
+                    noSleep();
+                });
+            }
+
+
             // Main
             window.onload = () => {
                 nextRound();
                 nextWind();
                 updateDisplay();
+
+                if (navigator.wakeLock)
+                    noSleep();          // Starts async loop
             }
 
             ROUND_INFO.addEventListener("click", nextRound);


### PR DESCRIPTION
The app currently works as intended, however some enhancements can be made to mobile to make using the app in a real-life environment a more appealing experience.

This branch adds:
- A wake lock to stop mobile devices from going to sleep using [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API)
- A fullscreen feature when you double click any of the wind icons using [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API)

I do not know the extent of support for these two APIs. I do know that the Screen Wake Lock API is very new and may not work in older browsers.

Tested fully on desktop firefox and everything works.

@mahtools/team-john see anything that could be improved with this? Including new additions?  